### PR TITLE
Python 3 compatibility

### DIFF
--- a/ipythonblocks/ipythonblocks.py
+++ b/ipythonblocks/ipythonblocks.py
@@ -16,6 +16,11 @@ from operator import iadd
 
 from IPython.display import HTML, display
 
+import sys
+if sys.version_info[0] >= 3:
+    xrange = range
+    from functools import reduce
+
 __all__ = ('Block', 'BlockGrid', 'InvalidColorSpec')
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,7 @@ setup(name='ipythonblocks',
       packages=['ipythonblocks'],
       classifiers=['License :: OSI Approved :: MIT License',
                    'Programming Language :: Python',
+                   'Programming Language :: Python :: 2',
+                   'Programming Language :: Python :: 3',
                    'Intended Audience :: Education',
                    'Topic :: Education'])


### PR DESCRIPTION
A tiny change needed to make it work under Python 3.

I haven't modified the demo notebook in this commit, but it's as simple as changing `xrange` to `range`. I can commit that too if you like.
