### PR TITLE
Test failures on Python 3.2 / IPython 0.13.1 / NumPy 1.6.2

### DIFF
--- a/ipythonblocks/ipythonblocks.py
+++ b/ipythonblocks/ipythonblocks.py
@@ -392,7 +392,8 @@ class BlockGrid(object):
         ind_cat = self._categorize_index(index)
 
         if ind_cat == _SINGLE_ROW:
-            map(lambda b: b.set_colors(*value), self._grid[index])
+            for b in self._grid[index]:
+                b.set_colors(*value)
 
         elif ind_cat == _SINGLE_ITEM:
             self._grid[index[0]][index[1]].set_colors(*value)
@@ -404,7 +405,8 @@ class BlockGrid(object):
             elif ind_cat == _DOUBLE_SLICE:
                 sub_grid = self._get_double_slice(index)
 
-            map(lambda b: b.set_colors(*value), itertools.chain(*sub_grid))
+            for b in itertools.chain(*sub_grid):
+                b.set_colors(*value)
 
     def _get_double_slice(self, index):
         sl_height, sl_width = index
@@ -674,7 +676,8 @@ class ImageGrid(BlockGrid):
             pixels.set_colors(*value)
 
         else:
-            map(lambda p: p.set_colors(*value), itertools.chain(*pixels._grid))
+            for p in itertools.chain(*pixels._grid):
+                p.set_colors(*value)
 
     def _get_double_slice(self, index):
         cslice, rslice = index


### PR DESCRIPTION
The failure in `test_setitem` ends with:

```
        # single row
        bg[2] = colors
        for block in bg[2]:
>           assert block.rgb == colors
E           assert (1, 2, 3) == (21, 22, 23)
E             At index 0 diff: 1 != 21

ipythonblocks/test/test_blockgrid.py:284: AssertionError
```

The failure in `test_setitem_lower_left_slice` ends with:

```
        for pix in ll._grid[0]:
>           assert pix.red == 201
E           assert 7 == 201
E            +  where 7 = <ipythonblocks.ipythonblocks.Pixel object at 0x2d60ad0>.red

ipythonblocks/test/test_imagegrid.py:113: AssertionError
```

These both seem to have to do with some sort of slicing issue, but I haven't tracked down the particulars yet.  Python 2.7.3 (with the same IPython and NumPy) does pass the test suite.
