### PR TITLE
New Block method, set_color_by_name

### DIFF
--- a/ipythonblocks/ipythonblocks.py
+++ b/ipythonblocks/ipythonblocks.py
@@ -202,6 +202,40 @@ class Block(object):
         self.green = green
         self.blue = blue
 
+    def set_color_by_name(self, name):
+        """
+        Update block color using a named color.
+
+        Parameters
+        ----------
+        name : str
+            The name of a color. Currently supports 'red', 'green', or 'blue'
+
+        """
+        # HTML 4 color names
+        names_to_rgb = {'aqua': (0, 255, 255),
+                        'black': (0, 0, 0),
+                        'blue': (0, 0, 255),
+                        'fuchsia': (255, 0, 255),
+                        'green': (0, 128, 0),
+                        'grey': (128, 128, 128),
+                        'lime': (0, 255, 0),
+                        'maroon': (128, 0, 0),
+                        'navy': (0, 0, 128),
+                        'olive': (128, 128, 0),
+                        'purple': (128, 0, 128),
+                        'red': (255, 0, 0),
+                        'silver': (192, 192, 192),
+                        'teal': (0, 128, 128),
+                        'white': (255, 255, 255),
+                        'yellow': (255, 255, 0)}
+
+        normalized = name.lower()
+        if normalized not in names_to_rgb:
+            s = 'value must be a valid color name. got {0}.'.format(name)
+            raise InvalidColorSpec(s)
+        self.red, self.green, self.blue = names_to_rgb[normalized]
+
     @property
     def _td(self):
         """


### PR DESCRIPTION
Hi Matt,

I watched your PyCon 2013 talk about iPython blocks. I'm currently working on a children's intro to programming in Python class called Python Superpowers and I thought that ipythonblocks would be a great way to teach looping and conditional logic.

I was looking for a way to set block colors by name, to avoid the kids having to know anything about RGB. The Internet connectivity in our classroom is unfortunately known to be spotty, so the color picker was not an option. Instead, I added a set_color_by_name() method that supports the 16 HTML 4 colors to the Block class and it seems to work pretty well.

I tried to avoid external dependencies (webcolors), to keep the list of colors simple (HTML 4 colors and not the much longer list of CSS3 colors), and to add a new method instead of changing an existing one. I'd be happy to discuss these decisions.

As for the last point, a couple of options did occur to me:
1. Leaving Block.rgb() as is, Block.set_colors() could be changed to accept a color name instead of RGB values.  Perhaps set_colors() could be renamed to set_color() as well.
2. Leaving Block.rgb() as is, Block.set_colors() could be changed to accept EITHER RGB values or a color name.

I'd be happy to change this commit to either 1 or 2 if you think it would be better.

You can try out the color names using following code in a new notebook:

``` python
import ipythonblocks
grid = ipythonblocks.BlockGrid(4, 4)
colors = ('aqua', 'black', 'blue', 'fuchsia', 'green', 'grey',
          'lime', 'maroon', 'navy', 'olive', 'purple', 'red',
          'silver', 'teal', 'white', 'yellow')
i = 0
for b in grid.animate:
    b.set_color_by_name(colors[i])
    i += 1
```
