### PR TITLE
Optionally use setuptools for installation if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(name='ipythonblocks',
       version='1.6dev',


### PR DESCRIPTION
As it says in the tittle.  This does not include anything 'magic' like `distribute_setup.py` and does not use any features that _require_ setuptools.  Since this is an educational tool I agree that it should be as simple as possible.  But this will still install with setuptools where it's available so as to be able to take advantage of features like `./setup.py develop`.
