### PR TITLE
call clear_output first in flash

### DIFF
--- a/ipythonblocks/ipythonblocks.py
+++ b/ipythonblocks/ipythonblocks.py
@@ -622,9 +622,9 @@ class BlockGrid(object):
             Amount of time, in seconds, to display the grid.
 
         """
+        clear_output()
         self.show()
         time.sleep(display_time)
-        clear_output()
 
     def to_text(self, filename=None):
         """

--- a/ipythonblocks/test/test_misc.py
+++ b/ipythonblocks/test/test_misc.py
@@ -21,3 +21,28 @@ def test_flatten():
     for i, x in enumerate(ipythonblocks._flatten(thing)):
         assert x == i
 
+
+
+def test_flash_should_clear_first(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ipythonblocks, "clear_output", lambda: calls.append("clear_output"))
+    monkeypatch.setattr(ipythonblocks.BlockGrid, "show", lambda self: calls.append("show"))
+    monkeypatch.setattr("time.sleep", lambda interval: calls.append("sleep(%d)" % interval))
+    grid = ipythonblocks.BlockGrid(1, 1)
+    grid.flash(3)
+    assert calls[0] == "clear_output"
+    assert calls[1] == "show"
+    assert calls[2] == "sleep(3)"
+
+
+import os.path
+from os.path import expanduser
+def getssh(): # pseudo application code
+        return os.path.join(expanduser("~admin"), '.ssh')
+
+def test_mytest(monkeypatch):
+            def mockreturn(path):
+                        return '/abc'
+            monkeypatch.setattr(__name__+'.expanduser', mockreturn)
+            x = getssh()
+            assert x == '/abc/.ssh'

--- a/ipythonblocks/test/test_misc.py
+++ b/ipythonblocks/test/test_misc.py
@@ -22,7 +22,6 @@ def test_flatten():
         assert x == i
 
 
-
 def test_flash_should_clear_first(monkeypatch):
     calls = []
     monkeypatch.setattr(ipythonblocks, "clear_output", lambda: calls.append("clear_output"))
@@ -33,16 +32,3 @@ def test_flash_should_clear_first(monkeypatch):
     assert calls[0] == "clear_output"
     assert calls[1] == "show"
     assert calls[2] == "sleep(3)"
-
-
-import os.path
-from os.path import expanduser
-def getssh(): # pseudo application code
-        return os.path.join(expanduser("~admin"), '.ssh')
-
-def test_mytest(monkeypatch):
-            def mockreturn(path):
-                        return '/abc'
-            monkeypatch.setattr(__name__+'.expanduser', mockreturn)
-            x = getssh()
-            assert x == '/abc/.ssh'


### PR DESCRIPTION
It will make everybody's life slightly easier if we call clear_output first instead of last when flashing.
