### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
    :alt: Coveralls
    :target: https://coveralls.io/r/jiffyclub/ipythonblocks
 
-.. image:: https://pypip.in/v/ipythonblocks/badge.png
+.. image:: https://img.shields.io/pypi/v/ipythonblocks.svg
    :alt: PyPI
    :target: https://pypi.python.org/pypi/ipythonblocks
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ipythonblocks))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ipythonblocks`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.