### PR TITLE
Fix flickering in animations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/ipythonblocks/ipythonblocks.py
+++ b/ipythonblocks/ipythonblocks.py
@@ -576,7 +576,7 @@ class BlockGrid(object):
             self.show()
             time.sleep(stop_time)
             yield block
-            clear_output()
+            clear_output(wait=True)
         self.show()
 
     def _repr_html_(self):
@@ -625,7 +625,7 @@ class BlockGrid(object):
         """
         self.show()
         time.sleep(display_time)
-        clear_output()
+        clear_output(wait=True)
 
     def _calc_image_size(self):
         """

--- a/ipythonblocks/ipythonblocks.py
+++ b/ipythonblocks/ipythonblocks.py
@@ -25,7 +25,7 @@ from IPython.display import Image as ipyImage
 
 __all__ = ('Block', 'BlockGrid', 'Pixel', 'ImageGrid',
            'InvalidColorSpec', 'ShapeMismatch', 'show_color',
-           'embed_colorpicker', 'colors', 'fui_colors', '__version__')
+           'embed_colorpicker', 'clear', 'colors', 'fui_colors', '__version__')
 __version__ = '1.8dev'
 
 _TABLE = ('<style type="text/css">'
@@ -67,6 +67,16 @@ class ShapeMismatch(Exception):
 
     """
     pass
+
+
+def clear():
+    """
+    Clear the output of the current cell.
+
+    This is a thin wrapper around IPython.display.clear_output.
+
+    """
+    clear_output()
 
 
 def show_color(red, green, blue):
@@ -616,6 +626,10 @@ class BlockGrid(object):
         Display the grid for a time.
 
         Useful for making an animation or iteratively displaying changes.
+
+        Note that this will leave the grid in place until something replaces
+        it in the same cell. You can use the ``clear`` function to
+        manually clear output.
 
         Parameters
         ----------

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,8 @@ setup(name='ipythonblocks',
                    'Programming Language :: Python :: 3',
                    'Intended Audience :: Education',
                    'Topic :: Education'],
-      install_requires=['requests>=1.0'])
+      install_requires=[
+            'ipython>=4.0',
+            'notebook>=4.0',
+            'requests>=1.0',
+      ])


### PR DESCRIPTION
Adding `wait=True` to calls to `clear_output` makes it so there isn't a gap where nothing is displayed between animation frames.